### PR TITLE
Fix spurious gcc warnings with Boost patches from upstream

### DIFF
--- a/boost/bind/arg.hpp
+++ b/boost/bind/arg.hpp
@@ -21,6 +21,7 @@
 
 #include <boost/config.hpp>
 #include <boost/is_placeholder.hpp>
+#include <boost/static_assert.hpp>
 
 namespace boost
 {
@@ -33,8 +34,7 @@ template< int I > struct arg
 
     template< class T > arg( T const & /* t */ )
     {
-        // static assert I == is_placeholder<T>::value
-        typedef char T_must_be_placeholder[ I == is_placeholder<T>::value? 1: -1 ];
+        BOOST_STATIC_ASSERT( I == is_placeholder<T>::value );
     }
 };
 

--- a/boost/concept/detail/general.hpp
+++ b/boost/concept/detail/general.hpp
@@ -45,7 +45,7 @@ struct constraint
 {
     static void failed() { ((Model*)0)->constraints(); }
 };
-  
+
 template <class Model>
 struct requirement_<void(*)(Model)>
   : mpl::if_<
@@ -54,7 +54,7 @@ struct requirement_<void(*)(Model)>
       , requirement<failed ************ Model::************>
     >::type
 {};
-  
+
 # else
 
 // For GCC-2.x, these can't have exactly the same name
@@ -62,13 +62,22 @@ template <class Model>
 struct requirement_<void(*)(Model)>
     : requirement<failed ************ Model::************>
 {};
-  
+
 # endif
 
-#  define BOOST_CONCEPT_ASSERT_FN( ModelFnPtr )             \
+// Version check from https://svn.boost.org/trac/boost/changeset/82886
+// (boost/static_assert.hpp)
+#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))
+#define BOOST_CONCEPT_UNUSED_TYPEDEF __attribute__((unused))
+#else
+#define BOOST_CONCEPT_UNUSED_TYPEDEF /**/
+#endif
+
+#  define BOOST_CONCEPT_ASSERT_FN( ModelFnPtr )              \
     typedef ::boost::concepts::detail::instantiate<          \
     &::boost::concepts::requirement_<ModelFnPtr>::failed>    \
-      BOOST_PP_CAT(boost_concept_check,__LINE__)
+      BOOST_PP_CAT(boost_concept_check,__LINE__)             \
+      BOOST_CONCEPT_UNUSED_TYPEDEF
 
 }}
 


### PR DESCRIPTION
All warnings fixed for gcc4.8
