### PR TITLE
remove warnings from clang patch

### DIFF
--- a/boost/config/stdlib/libstdcpp3.hpp
+++ b/boost/config/stdlib/libstdcpp3.hpp
@@ -121,21 +121,18 @@
 //
 #ifdef __clang__
 
-#if __has_include(<array>)
-#  define BOOST_LIBSTDCXX_VERSION 40300
-#endif
-#if __has_include(<ratio>)
-#  define BOOST_LIBSTDCXX_VERSION 40400
-#endif
-#if __has_include(<future>)
-#  define BOOST_LIBSTDCXX_VERSION 40500
-#endif
-#if __has_include(<typeindex>)
-#  define BOOST_LIBSTDCXX_VERSION 40600
-#endif
 #if __has_include(<chrono>)
 #  define BOOST_LIBSTDCXX_VERSION 40700
+#elif __has_include(<typeindex>)
+#  define BOOST_LIBSTDCXX_VERSION 40600
+#elif __has_include(<future>)
+#  define BOOST_LIBSTDCXX_VERSION 40500
+#elif __has_include(<ratio>)
+#  define BOOST_LIBSTDCXX_VERSION 40400
+#elif __has_include(<array>)
+#  define BOOST_LIBSTDCXX_VERSION 40300
 #endif
+
 //
 //  GCC 4.8 and 9 add working versions of <atomic> and <regex> respectively.
 //  However, we have no test for these as the headers were present but broken


### PR DESCRIPTION
The patch created some warnings, which are all fixed in this PR.
