### PR TITLE
Adding BOOST_NO_AUTO_PTR define

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,7 +6,7 @@ of every change, see the Git log.
 
 Latest
 ------
-* tbd
+* Major: Adding BOOST_NO_AUTO_PTR define remove any use of auto_ptr in Boost.
 
 2.0.0
 -----

--- a/wscript
+++ b/wscript
@@ -61,7 +61,14 @@ def _boost_shared_defines(conf):
     returns shared defines for boost
     """
 
-    defines = ['BOOST_ALL_NO_LIB=1', 'BOOST_DETAIL_NO_CONTAINER_FWD']
+    defines = ['BOOST_ALL_NO_LIB=1',
+               'BOOST_DETAIL_NO_CONTAINER_FWD',
+               # auto_ptr is in the process of being deprecated in C++ and newer
+               # compilers will emit warnings when compiling code using
+               # auto_ptr. Boost uses auto_ptr in various places by defining
+               # BOOST_NO_AUTO_PTR we basically say we want to compile without
+               # support for auto_ptr.
+               'BOOST_NO_AUTO_PTR']
 
     CXX = conf.env.get_flat("CXX")
     # Disable the noexcept keyword for all compilers


### PR DESCRIPTION
Removes warnings regarding use of the deprecated auto_ptr